### PR TITLE
Move configuration of MQTT server port

### DIFF
--- a/src/PrivateConfig.h
+++ b/src/PrivateConfig.h
@@ -6,3 +6,4 @@ const String   WIFI_PASS = "Enter wireless password here";     // wifi password
 const String   MQTT_SERVER = "Enter mqtt server address here"; // mqtt server address without port number
 const String   MQTT_USER   = "Enter mqtt username here";       // mqtt user. Use "" for no username
 const String   MQTT_PASS   = "Enter mqtt password here";       // mqtt password. Use "" for no password
+const uint16_t MQTT_PORT   = 1883;                             // mqtt port

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,6 @@ const String   MQTT_VALUE_MODE_STANDBY  = "off";
 const String   MQTT_VALUE_MODE_MANUAL   = "heat";
 
 const String   MQTT_CLIENT = "Wavin-AHC-9000-mqtt";       // mqtt client_id prefix. Will be suffixed with Esp8266 mac to make it unique
-const uint16_t MQTT_PORT   = 1883;                        // mqtt port
 
 String mqttDeviceNameWithMac;
 String mqttClientWithMac;


### PR DESCRIPTION
Move MQTT_PORT into configuration header for easier configuration as not
all MQTT brokers use the default port.

Changed serial configuration as Serial.begin(baud) will default to using
8 bits with 1 stop bit while Wavin communicates 8 bits and 2 stop bits.

Communication will sort of work with one stop bit but have a high error
rate. This is easily mitigated by simply trying one more time but I
find that using 2 stop bits has zero errors.