### PR TITLE
Simple OTA support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,10 @@ upload_speed = 115200
 
 lib_deps =
   PubSubClient@2.6
+  ArduinoOTA
 
 ; Larger buffer is needed for HomeAssistant discovery messages, which are quite large
 build_flags = -D MQTT_MAX_PACKET_SIZE=1024
+
+#upload_protocol = espota
+#upload_port = ; IP_ADDRESS_HERE or mDNS_NAME.local

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <ESP8266WiFi.h>
 #include <PubSubClient.h>
+#include <ArduinoOTA.h>
 #include "WavinController.h"
 #include "PrivateConfig.h"
 
@@ -223,8 +224,49 @@ void setup()
 
   mqttClient.setServer(MQTT_SERVER.c_str(), MQTT_PORT);
   mqttClient.setCallback(mqttCallback);
-}
 
+  ArduinoOTA.setHostname("wavin");
+
+  ArduinoOTA.onStart([]() {
+    String type;
+    if (ArduinoOTA.getCommand() == U_FLASH) {
+      type = "sketch";
+    } else { // U_FS
+      type = "filesystem";
+    }
+
+    // Print to USB instead of Wavin
+    Serial.swap();
+
+    // NOTE: if updating FS this would be the place to unmount FS using FS.end()
+    Serial.println("Start updating " + type);
+  });
+
+  ArduinoOTA.onEnd([]() {
+    Serial.println("\nEnd");
+  });
+
+  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+    Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+  });
+
+  ArduinoOTA.onError([](ota_error_t error) {
+    Serial.printf("Error[%u]: ", error);
+    if (error == OTA_AUTH_ERROR) {
+      Serial.println("Auth Failed");
+    } else if (error == OTA_BEGIN_ERROR) {
+      Serial.println("Begin Failed");
+    } else if (error == OTA_CONNECT_ERROR) {
+      Serial.println("Connect Failed");
+    } else if (error == OTA_RECEIVE_ERROR) {
+      Serial.println("Receive Failed");
+    } else if (error == OTA_END_ERROR) {
+      Serial.println("End Failed");
+    }
+  });
+
+  ArduinoOTA.begin();
+}
 
 void loop()
 {
@@ -238,6 +280,9 @@ void loop()
 
   if (WiFi.status() == WL_CONNECTED)
   {
+    // OTA
+    ArduinoOTA.handle();
+
     if (!mqttClient.connected())
     {
       String will = String(MQTT_PREFIX + mqttDeviceNameWithMac + MQTT_ONLINE);


### PR DESCRIPTION
Even if the project is stable in terms of Wavin support, I think we may need to adapt to Home-assistant changes in future, so OTA will definitely be nice to have.

@paller made a nice OTA support in his fork, which fixes #12. 
I suggest we join forces here in @dkjonas's original repo, hence this PR mainly with paller's code :-)

My minor contribution was to add upload port definitions to platformio.ini. 
I kept the definitions commented, to not interfere with first-time uploads via USB.